### PR TITLE
Expose governance proposal helpers

### DIFF
--- a/taurus-protect-sdk-go/pkg/protect/mapper/rules_container.go
+++ b/taurus-protect-sdk-go/pkg/protect/mapper/rules_container.go
@@ -2,12 +2,17 @@ package mapper
 
 import (
 	"encoding/base64"
+	"encoding/json"
 	"fmt"
+	"strings"
 
 	pb "github.com/taurushq-io/taurus-protect-sdk/taurus-protect-sdk-go/internal/proto"
 	"github.com/taurushq-io/taurus-protect-sdk/taurus-protect-sdk-go/pkg/protect/crypto"
 	"github.com/taurushq-io/taurus-protect-sdk/taurus-protect-sdk-go/pkg/protect/model"
+	"google.golang.org/protobuf/encoding/protojson"
 	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/reflect/protoreflect"
+	"google.golang.org/protobuf/reflect/protoregistry"
 )
 
 // RulesContainerFromBase64 decodes a base64-encoded protobuf RulesContainer into a model.
@@ -28,6 +33,78 @@ func RulesContainerFromBytes(data []byte) (*model.DecodedRulesContainer, error) 
 	}
 
 	return rulesContainerFromProto(&pbContainer)
+}
+
+// RulesContainerJSONFromBase64 decodes a base64-encoded protobuf RulesContainer into proto JSON.
+//
+// The returned JSON keeps the canonical protobuf field names and base64-encoded byte
+// fields expected by protojson. It is suitable for round-tripping through
+// RulesContainerBase64FromJSON without going through the lossy DecodedRulesContainer
+// convenience model.
+func RulesContainerJSONFromBase64(base64Data string) (json.RawMessage, error) {
+	data, err := base64.StdEncoding.DecodeString(base64Data)
+	if err != nil {
+		return nil, fmt.Errorf("failed to decode base64: %w", err)
+	}
+	var pbContainer pb.RulesContainer
+	if err := proto.Unmarshal(data, &pbContainer); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal protobuf: %w", err)
+	}
+	jsonData, err := protojson.Marshal(&pbContainer)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal rules container JSON: %w", err)
+	}
+	return json.RawMessage(jsonData), nil
+}
+
+// RulesContainerBase64FromJSON encodes proto JSON into a base64 protobuf RulesContainer.
+func RulesContainerBase64FromJSON(jsonData []byte) (string, error) {
+	var pbContainer pb.RulesContainer
+	if err := protojson.Unmarshal(jsonData, &pbContainer); err != nil {
+		return "", fmt.Errorf("failed to unmarshal rules container JSON: %w", err)
+	}
+	data, err := proto.Marshal(&pbContainer)
+	if err != nil {
+		return "", fmt.Errorf("failed to marshal rules container protobuf: %w", err)
+	}
+	return base64.StdEncoding.EncodeToString(data), nil
+}
+
+// RuleMessageBase64FromJSON encodes a governance rule protobuf message into base64.
+//
+// messageType must be one of the concrete rule message names from request_reply.proto
+// such as RuleSource, RuleDestination, RuleFiatAmount, RulesContainer_Line, or
+// RulesContainer_TransactionRules. This helper exists so callers outside the SDK
+// do not need to import the generated internal proto package.
+func RuleMessageBase64FromJSON(messageType string, jsonData []byte) (string, error) {
+	message, err := newGovernanceRuleMessage(messageType)
+	if err != nil {
+		return "", err
+	}
+	if err := protojson.Unmarshal(jsonData, message); err != nil {
+		return "", fmt.Errorf("failed to unmarshal %s JSON: %w", strings.TrimSpace(messageType), err)
+	}
+	data, err := proto.Marshal(message)
+	if err != nil {
+		return "", fmt.Errorf("failed to marshal %s protobuf: %w", strings.TrimSpace(messageType), err)
+	}
+	return base64.StdEncoding.EncodeToString(data), nil
+}
+
+func newGovernanceRuleMessage(messageType string) (proto.Message, error) {
+	name := strings.TrimSpace(messageType)
+	if name == "" {
+		return nil, fmt.Errorf("messageType cannot be empty")
+	}
+	fullName := protoreflect.FullName(strings.ReplaceAll(name, "_", "."))
+	if pkg := pb.File_request_reply_proto.Package(); pkg != "" {
+		fullName = protoreflect.FullName(string(pkg) + "." + string(fullName))
+	}
+	message, err := protoregistry.GlobalTypes.FindMessageByName(fullName)
+	if err != nil {
+		return nil, fmt.Errorf("unsupported governance rule message type %q", messageType)
+	}
+	return message.New().Interface(), nil
 }
 
 // rulesContainerFromProto converts a protobuf RulesContainer to the model.

--- a/taurus-protect-sdk-go/pkg/protect/mapper/rules_container.go
+++ b/taurus-protect-sdk-go/pkg/protect/mapper/rules_container.go
@@ -91,6 +91,34 @@ func RuleMessageBase64FromJSON(messageType string, jsonData []byte) (string, err
 	return base64.StdEncoding.EncodeToString(data), nil
 }
 
+// RuleMessageJSONFromBase64 decodes a base64-encoded protobuf rule message
+// back into canonical protobuf JSON. This is the reverse of RuleMessageBase64FromJSON.
+// Returns nil, nil for empty input (empty cells mean "match any").
+func RuleMessageJSONFromBase64(messageType string, base64Data string) (json.RawMessage, error) {
+	if strings.TrimSpace(base64Data) == "" {
+		return nil, nil
+	}
+	data, err := base64.StdEncoding.DecodeString(base64Data)
+	if err != nil {
+		return nil, fmt.Errorf("failed to decode base64: %w", err)
+	}
+	if len(data) == 0 {
+		return nil, nil
+	}
+	message, err := newGovernanceRuleMessage(messageType)
+	if err != nil {
+		return nil, err
+	}
+	if err := proto.Unmarshal(data, message); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal %s protobuf: %w", strings.TrimSpace(messageType), err)
+	}
+	jsonData, err := protojson.Marshal(message)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal %s JSON: %w", strings.TrimSpace(messageType), err)
+	}
+	return jsonData, nil
+}
+
 func newGovernanceRuleMessage(messageType string) (proto.Message, error) {
 	name := strings.TrimSpace(messageType)
 	if name == "" {

--- a/taurus-protect-sdk-go/pkg/protect/mapper/rules_container_json_test.go
+++ b/taurus-protect-sdk-go/pkg/protect/mapper/rules_container_json_test.go
@@ -1,0 +1,70 @@
+package mapper
+
+import (
+	"encoding/base64"
+	"fmt"
+	"testing"
+
+	pb "github.com/taurushq-io/taurus-protect-sdk/taurus-protect-sdk-go/internal/proto"
+	"google.golang.org/protobuf/proto"
+)
+
+func TestRulesContainerJSONRoundTripPreservesProto(t *testing.T) {
+	container := createTestRulesContainer()
+	encoded := encodeRulesContainerToBase64(t, container)
+
+	jsonData, err := RulesContainerJSONFromBase64(encoded)
+	if err != nil {
+		t.Fatalf("RulesContainerJSONFromBase64() error = %v", err)
+	}
+
+	encodedAgain, err := RulesContainerBase64FromJSON(jsonData)
+	if err != nil {
+		t.Fatalf("RulesContainerBase64FromJSON() error = %v", err)
+	}
+
+	got := decodeRulesContainerProto(t, encodedAgain)
+	if !proto.Equal(container, got) {
+		t.Fatalf("round-tripped container differs\nwant: %v\ngot: %v", container, got)
+	}
+}
+
+func TestRuleMessageBase64FromJSONEncodesRuleCells(t *testing.T) {
+	walletPayload, err := RuleMessageBase64FromJSON("RuleSourceInternalWallet", []byte(`{"path":"m/44'/60'/0'/0/0"}`))
+	if err != nil {
+		t.Fatalf("RuleMessageBase64FromJSON(wallet) error = %v", err)
+	}
+	sourceJSON := []byte(fmt.Sprintf(`{"type":"RuleSourceInternalWallet","payload":%q}`, walletPayload))
+	sourceCell, err := RuleMessageBase64FromJSON("RuleSource", sourceJSON)
+	if err != nil {
+		t.Fatalf("RuleMessageBase64FromJSON(source) error = %v", err)
+	}
+	sourceBytes, err := base64.StdEncoding.DecodeString(sourceCell)
+	if err != nil {
+		t.Fatalf("decode source cell: %v", err)
+	}
+	var source pb.RuleSource
+	if err := proto.Unmarshal(sourceBytes, &source); err != nil {
+		t.Fatalf("unmarshal source cell: %v", err)
+	}
+	if source.GetType() != pb.RuleSource_RuleSourceInternalWallet {
+		t.Fatalf("source type = %v", source.GetType())
+	}
+	_, err = RuleMessageBase64FromJSON("NoSuchRuleMessage", []byte(`{}`))
+	if err == nil {
+		t.Fatal("RuleMessageBase64FromJSON() expected error")
+	}
+}
+
+func decodeRulesContainerProto(t *testing.T, encoded string) *pb.RulesContainer {
+	t.Helper()
+	data, err := base64.StdEncoding.DecodeString(encoded)
+	if err != nil {
+		t.Fatalf("decode base64: %v", err)
+	}
+	var container pb.RulesContainer
+	if err := proto.Unmarshal(data, &container); err != nil {
+		t.Fatalf("unmarshal rules container: %v", err)
+	}
+	return &container
+}

--- a/taurus-protect-sdk-go/pkg/protect/service/governance_rule.go
+++ b/taurus-protect-sdk-go/pkg/protect/service/governance_rule.go
@@ -149,6 +149,26 @@ func (s *GovernanceRuleService) GetRulesProposal(ctx context.Context) (*model.Go
 	return mapper.GovernanceRulesetFromDTO(resp.Result), nil
 }
 
+// UpdateRulesProposal updates the proposed governance rules.
+// The rulesContainer must be a base64-encoded protobuf RulesContainer.
+func (s *GovernanceRuleService) UpdateRulesProposal(ctx context.Context, rulesContainer string) (map[string]interface{}, error) {
+	if rulesContainer == "" {
+		return nil, fmt.Errorf("rulesContainer cannot be empty")
+	}
+
+	body := openapi.TgvalidatordUpdateRulesProposalRequest{
+		RulesContainer: rulesContainer,
+	}
+	resp, httpResp, err := s.api.RuleServiceUpdateRulesProposal(ctx).
+		Body(body).
+		Execute()
+	if err != nil {
+		return nil, s.errMapper.MapError(err, httpResp)
+	}
+
+	return resp, nil
+}
+
 // GetPublicKeys retrieves the list of SuperAdmin public keys.
 func (s *GovernanceRuleService) GetPublicKeys(ctx context.Context) ([]*model.SuperAdminPublicKey, error) {
 	resp, httpResp, err := s.api.RuleServiceGetPublicKeys(ctx).Execute()

--- a/taurus-protect-sdk-go/pkg/protect/service/governance_rule_test.go
+++ b/taurus-protect-sdk-go/pkg/protect/service/governance_rule_test.go
@@ -42,6 +42,20 @@ func TestGovernanceRuleService_GetRulesByID_Validation(t *testing.T) {
 	}
 }
 
+func TestGovernanceRuleService_UpdateRulesProposal_Validation(t *testing.T) {
+	s := &GovernanceRuleService{
+		errMapper: NewErrorMapper(),
+	}
+
+	_, err := s.UpdateRulesProposal(nil, "")
+	if err == nil {
+		t.Fatal("UpdateRulesProposal() expected error for empty rulesContainer")
+	}
+	if err.Error() != "rulesContainer cannot be empty" {
+		t.Fatalf("UpdateRulesProposal() error = %q", err.Error())
+	}
+}
+
 func TestGovernanceRulesHistoryOptions(t *testing.T) {
 	tests := []struct {
 		name string

--- a/taurus-protect-sdk-go/pkg/protect/service/wallet.go
+++ b/taurus-protect-sdk-go/pkg/protect/service/wallet.go
@@ -253,6 +253,9 @@ func mapOpenAPIError(err *openapi.GenericOpenAPIError, resp *http.Response) erro
 
 	code := resp.StatusCode
 	message := err.Error()
+	if body := err.Body(); len(body) > 0 {
+		message = fmt.Sprintf("%s: %s", message, string(body))
+	}
 
 	// Create typed error based on status code
 	switch {


### PR DESCRIPTION

## Summary
- Expose helpers to convert rules containers between base64 protobuf and proto JSON for proposal editing.
- Expose rule message JSON-to-base64 encoding for governance rule cells.
- Add an SDK service method to submit updated governance rule proposals.

This intentionally exposes only what is strictly needed by the MCP workflow, keeping the SDK surface minimal and protobuf internals owned by the SDK.

## Test Plan
- `go test ./...`
