### PR TITLE
Fix type generation for metadata.payload to support raw json message

### DIFF
--- a/docs/CONCEPTS.md
+++ b/docs/CONCEPTS.md
@@ -82,7 +82,7 @@ Contains the cryptographically signed details of a request.
 | Property | Description |
 |----------|-------------|
 | `hash` | SHA-256 hash of the payload |
-| `payload` | Parsed transaction details (source, destination, amount) |
+| `payload` | Any valid JSON value (object, array, string, number, boolean, or null) |
 | `payloadAsString` | Raw JSON string for verification |
 
 ### Transaction

--- a/scripts/resources/swagger/apis.swagger.json
+++ b/scripts/resources/swagger/apis.swagger.json
@@ -36202,13 +36202,16 @@
         }
       }
     },
+    "tgvalidatordJsonValue": {},
     "tgvalidatordMetadata": {
       "type": "object",
       "properties": {
         "hash": {
           "type": "string"
         },
-        "payload": {},
+        "payload": {
+          "$ref": "#/definitions/tgvalidatordJsonValue"
+        },
         "payloadAsString": {
           "type": "string"
         }

--- a/taurus-protect-sdk-go/internal/openapi/model_tgvalidatord_metadata.go
+++ b/taurus-protect-sdk-go/internal/openapi/model_tgvalidatord_metadata.go
@@ -20,7 +20,7 @@ var _ MappedNullable = &TgvalidatordMetadata{}
 // TgvalidatordMetadata struct for TgvalidatordMetadata
 type TgvalidatordMetadata struct {
 	Hash *string `json:"hash,omitempty"`
-	Payload map[string]interface{} `json:"payload,omitempty"`
+	Payload json.RawMessage `json:"payload,omitempty"`
 	PayloadAsString *string `json:"payloadAsString,omitempty"`
 }
 
@@ -74,9 +74,9 @@ func (o *TgvalidatordMetadata) SetHash(v string) {
 }
 
 // GetPayload returns the Payload field value if set, zero value otherwise.
-func (o *TgvalidatordMetadata) GetPayload() map[string]interface{} {
+func (o *TgvalidatordMetadata) GetPayload() json.RawMessage {
 	if o == nil || IsNil(o.Payload) {
-		var ret map[string]interface{}
+		var ret json.RawMessage
 		return ret
 	}
 	return o.Payload
@@ -84,9 +84,9 @@ func (o *TgvalidatordMetadata) GetPayload() map[string]interface{} {
 
 // GetPayloadOk returns a tuple with the Payload field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-func (o *TgvalidatordMetadata) GetPayloadOk() (map[string]interface{}, bool) {
+func (o *TgvalidatordMetadata) GetPayloadOk() (json.RawMessage, bool) {
 	if o == nil || IsNil(o.Payload) {
-		return map[string]interface{}{}, false
+		return json.RawMessage{}, false
 	}
 	return o.Payload, true
 }
@@ -100,8 +100,8 @@ func (o *TgvalidatordMetadata) HasPayload() bool {
 	return false
 }
 
-// SetPayload gets a reference to the given map[string]interface{} and assigns it to the Payload field.
-func (o *TgvalidatordMetadata) SetPayload(v map[string]interface{}) {
+// SetPayload gets a reference to the given json.RawMessage and assigns it to the Payload field.
+func (o *TgvalidatordMetadata) SetPayload(v json.RawMessage) {
 	o.Payload = v
 }
 
@@ -138,7 +138,7 @@ func (o *TgvalidatordMetadata) SetPayloadAsString(v string) {
 }
 
 func (o TgvalidatordMetadata) MarshalJSON() ([]byte, error) {
-	toSerialize,err := o.ToMap()
+	toSerialize, err := o.ToMap()
 	if err != nil {
 		return []byte{}, err
 	}
@@ -194,5 +194,3 @@ func (v *NullableTgvalidatordMetadata) UnmarshalJSON(src []byte) error {
 	v.isSet = true
 	return json.Unmarshal(src, &v.value)
 }
-
-

--- a/taurus-protect-sdk-go/pkg/protect/mapper/metadata_payload_test.go
+++ b/taurus-protect-sdk-go/pkg/protect/mapper/metadata_payload_test.go
@@ -1,0 +1,48 @@
+package mapper
+
+import (
+	"bytes"
+	"encoding/json"
+	"testing"
+
+	"github.com/taurushq-io/taurus-protect-sdk/taurus-protect-sdk-go/internal/openapi"
+)
+
+func TestTgvalidatordMetadataPayload_AcceptsAnyValidJSONRoot(t *testing.T) {
+	tests := []struct {
+		name    string
+		payload string
+	}{
+		{name: "object", payload: `{"k":"v","n":1}`},
+		{name: "array", payload: `[1,"two",{"k":"v"}]`},
+		{name: "string", payload: `"plain-string"`},
+		{name: "number", payload: `123.45`},
+		{name: "boolean", payload: `true`},
+		{name: "null", payload: `null`},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			meta := openapi.NewTgvalidatordMetadata()
+			meta.SetPayload(json.RawMessage(tt.payload))
+
+			if !json.Valid(meta.GetPayload()) {
+				t.Fatalf("payload is not valid JSON: %q", meta.GetPayload())
+			}
+
+			encoded, err := json.Marshal(meta)
+			if err != nil {
+				t.Fatalf("marshal metadata: %v", err)
+			}
+
+			var decoded openapi.TgvalidatordMetadata
+			if err := json.Unmarshal(encoded, &decoded); err != nil {
+				t.Fatalf("unmarshal metadata: %v", err)
+			}
+
+			if !bytes.Equal(decoded.GetPayload(), []byte(tt.payload)) {
+				t.Fatalf("decoded payload mismatch: got=%s want=%s", decoded.GetPayload(), tt.payload)
+			}
+		})
+	}
+}

--- a/taurus-protect-sdk-go/pkg/protect/mapper/request_test.go
+++ b/taurus-protect-sdk-go/pkg/protect/mapper/request_test.go
@@ -1,6 +1,7 @@
 package mapper
 
 import (
+	"encoding/json"
 	"testing"
 	"time"
 
@@ -76,7 +77,7 @@ func TestRequestFromDTO(t *testing.T) {
 func TestRequestFromDTO_WithMetadata(t *testing.T) {
 	hash := "abc123"
 	payloadString := `{"key":"value"}`
-	payload := map[string]interface{}{"key": "value"}
+	payload := json.RawMessage(`{"key":"value"}`)
 	dto := &openapi.TgvalidatordRequest{
 		Metadata: &openapi.TgvalidatordMetadata{
 			Hash:            &hash,
@@ -199,7 +200,7 @@ func TestMetadataFromDTO(t *testing.T) {
 			dto: func() *openapi.TgvalidatordMetadata {
 				hash := "hash123"
 				payloadAsString := `{"data":"test"}`
-				payload := map[string]interface{}{"data": "test"}
+				payload := json.RawMessage(`{"data":"test"}`)
 				return &openapi.TgvalidatordMetadata{
 					Hash:            &hash,
 					PayloadAsString: &payloadAsString,

--- a/taurus-protect-sdk-go/pkg/protect/mapper/whitelisted_address_test.go
+++ b/taurus-protect-sdk-go/pkg/protect/mapper/whitelisted_address_test.go
@@ -1,6 +1,7 @@
 package mapper
 
 import (
+	"encoding/json"
 	"testing"
 	"time"
 
@@ -92,10 +93,7 @@ func TestWhitelistedAddressFromDTO_WithMetadata(t *testing.T) {
 		Metadata: &openapi.TgvalidatordMetadata{
 			Hash:            &hash,
 			PayloadAsString: &payloadAsString,
-			Payload: map[string]interface{}{
-				"address": "0x123",
-				"label":   "Test Address",
-			},
+			Payload:         json.RawMessage(`{"address":"0x123","label":"Test Address"}`),
 		},
 	}
 
@@ -180,7 +178,7 @@ func TestWhitelistedAssetMetadataFromDTO_WhitelistedAddress(t *testing.T) {
 				return &openapi.TgvalidatordMetadata{
 					Hash:            &hash,
 					PayloadAsString: &payloadAsString,
-					Payload:         map[string]interface{}{"key": "value"},
+					Payload:         json.RawMessage(`{"key":"value"}`),
 				}
 			}(),
 		},

--- a/taurus-protect-sdk-go/pkg/protect/mapper/whitelisted_asset_test.go
+++ b/taurus-protect-sdk-go/pkg/protect/mapper/whitelisted_asset_test.go
@@ -1,6 +1,7 @@
 package mapper
 
 import (
+	"encoding/json"
 	"testing"
 	"time"
 
@@ -157,7 +158,7 @@ func TestWhitelistedAssetMetadataFromDTO(t *testing.T) {
 				payloadAsString := `{"key":"value"}`
 				return &openapi.TgvalidatordMetadata{
 					Hash:            &hash,
-					Payload:         map[string]interface{}{"key": "value"},
+					Payload:         json.RawMessage(`{"key":"value"}`),
 					PayloadAsString: &payloadAsString,
 				}
 			}(),

--- a/taurus-protect-sdk-go/scripts/generate-openapi.sh
+++ b/taurus-protect-sdk-go/scripts/generate-openapi.sh
@@ -48,7 +48,10 @@ java -jar "$GENERATOR_JAR" generate -g go -i "$SPEC_FILE" -o .codegen \
     --skip-validate-spec \
     --additional-properties=packageName=openapi \
     --additional-properties=isGoSubmodule=true \
-    --additional-properties=enumClassPrefix=true
+    --additional-properties=enumClassPrefix=true \
+    --schema-mappings=tgvalidatordJsonValue=json.RawMessage \
+    --import-mappings=json.RawMessage=encoding/json \
+    --language-specific-primitives=json.RawMessage
 
 # Copy generated files to internal/openapi
 cp -R .codegen/*.go internal/openapi/ 2>/dev/null || true

--- a/taurus-protect-sdk-python/scripts/generate-openapi.sh
+++ b/taurus-protect-sdk-python/scripts/generate-openapi.sh
@@ -74,6 +74,9 @@ generate() {
         -i "$OPENAPI_SPEC" \
         -o "$TEMP_DIR" \
         --skip-validate-spec \
+        --schema-mappings=tgvalidatordJsonValue=Any \
+        --type-mappings=tgvalidatordJsonValue=Any \
+        --language-specific-primitives=Any \
         --additional-properties=packageName=taurus_protect._internal.openapi \
         --additional-properties=projectName=taurus-protect-openapi \
         --additional-properties=pythonAttrNoneIfUnset=true \

--- a/taurus-protect-sdk-python/taurus_protect/_internal/openapi/models/tgvalidatord_metadata.py
+++ b/taurus-protect-sdk-python/taurus_protect/_internal/openapi/models/tgvalidatord_metadata.py
@@ -27,7 +27,7 @@ class TgvalidatordMetadata(BaseModel):
     TgvalidatordMetadata
     """ # noqa: E501
     hash: Optional[StrictStr] = None
-    payload: Optional[Dict[str, Any]] = None
+    payload: Optional[Any] = None
     payload_as_string: Optional[StrictStr] = Field(default=None, alias="payloadAsString")
     additional_properties: Dict[str, Any] = {}
     __properties: ClassVar[List[str]] = ["hash", "payload", "payloadAsString"]

--- a/taurus-protect-sdk-typescript/scripts/generate-openapi.sh
+++ b/taurus-protect-sdk-typescript/scripts/generate-openapi.sh
@@ -87,6 +87,9 @@ generate() {
         -i "$SPEC_FILE" \
         -o "$TEMP_DIR" \
         --skip-validate-spec \
+        --schema-mappings=tgvalidatordJsonValue=any \
+        --type-mappings=tgvalidatordJsonValue=any \
+        --language-specific-primitives=any \
         --additional-properties=typescriptThreePlus=true \
         --additional-properties=supportsES6=true \
         --additional-properties=withInterfaces=true \

--- a/taurus-protect-sdk-typescript/src/internal/openapi/models/TgvalidatordMetadata.ts
+++ b/taurus-protect-sdk-typescript/src/internal/openapi/models/TgvalidatordMetadata.ts
@@ -27,10 +27,10 @@ export interface TgvalidatordMetadata {
     hash?: string;
     /**
      * 
-     * @type {object}
+     * @type {any}
      * @memberof TgvalidatordMetadata
      */
-    payload?: object;
+    payload?: any;
     /**
      * 
      * @type {string}


### PR DESCRIPTION
# Description

## Context
In swagger api definition, `tgvalidatordMetadata` is defined as `{}` (empty schema), which is translated to `map[string]interface{}` and similar constructs in other sdks which is semantically incorrect as `tgvalidatordMetadata` can be any valid json.

This was causing an issue while using this sdk:
```
json: cannot unmarshal array into Go struct field TgvalidatordMetadata.result.metadata.payload of type map[string]interface {} (code=200)
```

## What this PR do?
This PR fixes this by defining payload as separate `tgvalidatordJsonValue` type in swagger definition and then enforcing that it needs to be decoded into correct type which can take any json. Also, there are tests to validate this in go sdk.