### PR TITLE
Add filtering of wallet by blockchain and network

### DIFF
--- a/taurus-protect-sdk-go/pkg/protect/model/wallet.go
+++ b/taurus-protect-sdk-go/pkg/protect/model/wallet.go
@@ -104,6 +104,10 @@ type ListWalletsOptions struct {
 	Currency string
 	// Query searches wallet names.
 	Query string
+	// Blockchain filters by blockchain symbol.
+	Blockchain string
+	// Network filters by network or environment (e.g., "mainnet", "testnet").
+	Network string
 	// ExcludeDisabled excludes disabled wallets from results.
 	ExcludeDisabled bool
 }

--- a/taurus-protect-sdk-go/pkg/protect/service/wallet.go
+++ b/taurus-protect-sdk-go/pkg/protect/service/wallet.go
@@ -61,6 +61,12 @@ func (s *WalletService) ListWallets(ctx context.Context, opts *model.ListWallets
 		if opts.Query != "" {
 			req = req.Query(opts.Query)
 		}
+		if opts.Blockchain != "" {
+			req = req.Blockchain(opts.Blockchain)
+		}
+		if opts.Network != "" {
+			req = req.Network(opts.Network)
+		}
 		if opts.ExcludeDisabled {
 			req = req.ExcludeDisabled(true)
 		}


### PR DESCRIPTION
# Description

## Context
We want to use `ListWallet` exposed by sdk to filter wallets by blockchain and/or network. Current implementation in sdk does not support it.

## What this PR do?
This PR adds filtering of wallet by blockchain and network by adding blockchain and network to the `ListWalletOptions` and modify `ListWallet` to filter on it.